### PR TITLE
Fix state and default blocks.

### DIFF
--- a/syntaxes/zscript.tmLanguage.json
+++ b/syntaxes/zscript.tmLanguage.json
@@ -200,7 +200,7 @@
                 {
                     "name": "entity.other.default.block.zscript",
                     "begin": "(?i)(?<=^\\s*?\\bdefault\\b)",
-                    "end": "}",
+                    "end": "(?=})",
                     "patterns": [
                         {
                             "include": "#comments"

--- a/syntaxes/zscript.tmLanguage.json
+++ b/syntaxes/zscript.tmLanguage.json
@@ -200,7 +200,7 @@
                 {
                     "name": "entity.other.default.block.zscript",
                     "begin": "(?i)(?<=^\\s*?\\bdefault\\b)",
-                    "end": "(?<=^)\\s}",
+                    "end": "}",
                     "patterns": [
                         {
                             "include": "#comments"
@@ -234,7 +234,7 @@
                 {
                     "name": "entity.other.states.block.zscript",
                     "begin": "(?i)(?<=^\\s*?\\bstates\\b)",
-                    "end": "(?<=^)}",
+                    "end": "(?=})",
                     "patterns": [
                         {
                             "include": "#comments"
@@ -283,7 +283,7 @@
                 {
                     "name": "entity.other.enum.zscript",
                     "begin": "(?<=enum\\s\\w+?\\s$)",
-                    "end": "}",
+                    "end": "(?=})",
                     "patterns": [
                         {
                             "name": "constant.enum.value.zscript",


### PR DESCRIPTION
Previously, state and default blocks, when written one after another, would break the scopes. For instance, the state keyword was being highlighted as an identifier.